### PR TITLE
Capture invoice responses and generate invoice report

### DIFF
--- a/src/synthap/cli.py
+++ b/src/synthap/cli.py
@@ -247,11 +247,31 @@ def insert(
     async def _insert():
         batch_size = 50
         total_ok, total_fail = 0, 0
+        invoice_records = []
         for i in range(0, len(payloads), batch_size):
             batch = payloads[i : i + batch_size]
             try:
-                await post_invoices(batch)
-                total_ok += len(batch)
+                resp = await post_invoices(batch)
+                batch_invoices = resp.get("Invoices", [])
+                total_ok += len(batch_invoices)
+                for inv in batch_invoices:
+                    ref = inv.get("Reference")
+                    vendor = None
+                    if ref is not None:
+                        match = inv_df[inv_df["reference"] == ref]
+                        if not match.empty:
+                            vendor = match.iloc[0].get("vendor_id")
+                    invoice_records.append(
+                        {
+                            "InvoiceID": inv.get("InvoiceID"),
+                            "InvoiceNumber": inv.get("InvoiceNumber"),
+                            "Vendor": vendor,
+                            "Date": inv.get("Date"),
+                            "DueDate": inv.get("DueDate"),
+                            "Total": inv.get("Total"),
+                            "AmountDue": inv.get("AmountDue"),
+                        }
+                    )
             except Exception as e:
                 total_fail += len(batch)
                 typer.echo(f"Batch {i//batch_size} failed: {e}")
@@ -261,6 +281,7 @@ def insert(
             "inserted_failed": total_fail,
         }
         write_json(report, base / "insertion_report.json")
+        write_json(invoice_records, base / "invoice_report.json")
         typer.echo(f"[{run_id}] Inserted: {total_ok}, Failed: {total_fail}. Report saved.")
 
     asyncio.run(_insert())

--- a/src/synthap/reports/report.py
+++ b/src/synthap/reports/report.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 import orjson
-from typing import Any, Dict
+from typing import Any
 
-def write_json(obj: Dict[str, Any], path: Path) -> None:
+
+def write_json(obj: Any, path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(orjson.dumps(obj, option=orjson.OPT_INDENT_2))


### PR DESCRIPTION
## Summary
- Collect detailed information from Xero API responses during `insert`
- Store per-invoice details in a new `invoice_report.json`
- Allow `write_json` to handle non-dict objects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5a9ebd3908320845e971d91f2d760