### PR TITLE
Add optional AI-generated line item descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Synthetic AP
+
+This project generates synthetic accounts payable invoices for testing and demos.
+
+## AI line item descriptions
+
+To have invoice lines use realistic descriptions rather than the raw catalog item
+names, enable the feature in `data/config/runtime_config.yaml`:
+
+```yaml
+ai:
+  line_item_description_enabled: true
+  line_item_description_prompt: "Write a short description for invoice line item '{item_name}'."
+```
+
+Defaults live in `data/config/service_defaults.yaml` and can be overridden at
+runtime. When enabled the generator will call OpenAI to craft a natural
+description for each line item while keeping it consistent with the catalog's
+item name.
+

--- a/data/config/runtime_config.yaml
+++ b/data/config/runtime_config.yaml
@@ -6,6 +6,8 @@ ai:
   max_output_tokens: 1200
   system_prompt: null
   max_vendors: 6
+  line_item_description_enabled: false
+  line_item_description_prompt: "Write a short description for invoice line item '{item_name}'."
 generator:
   allow_price_variation: false
   price_variation_pct: 0.1

--- a/data/config/service_defaults.yaml
+++ b/data/config/service_defaults.yaml
@@ -13,5 +13,7 @@ ai:
   model: "gpt-4o-mini"
   temperature: 0.2
   max_vendors: 6
+  line_item_description_enabled: false
+  line_item_description_prompt: "Write a short description for invoice line item '{item_name}'."
 
 force_no_tax: false

--- a/src/synthap/ai/descriptions.py
+++ b/src/synthap/ai/descriptions.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..config.runtime_config import AIConfig
+
+
+def generate_line_description(item_name: str, cfg: AIConfig) -> str:
+    """Generate a realistic invoice line description for a given item name.
+
+    Falls back to the raw item name if the OpenAI request fails for any reason.
+    """
+    from openai import OpenAI
+
+    from ..config.settings import settings
+
+    prompt = cfg.line_item_description_prompt.format(item_name=item_name)
+    system = cfg.system_prompt or (
+        "You craft concise, realistic descriptions for invoice line items."
+    )
+    client = OpenAI(api_key=settings.openai_api_key)
+    try:
+        resp = client.chat.completions.create(
+            model=cfg.model,
+            temperature=float(cfg.temperature),
+            top_p=float(cfg.top_p),
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": prompt},
+            ],
+        )
+        return resp.choices[0].message.content.strip()
+    except Exception:
+        return item_name

--- a/src/synthap/config/runtime_config.py
+++ b/src/synthap/config/runtime_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional, Any, Dict
+from typing import Any
 
 import yaml
 from pydantic import BaseModel, Field
@@ -15,8 +15,12 @@ class AIConfig(BaseModel):
     temperature: float = 0.15
     top_p: float = 1.0
     max_output_tokens: int = 1200
-    system_prompt: Optional[str] = None
+    system_prompt: str | None = None
     max_vendors: int = 6
+    line_item_description_enabled: bool = False
+    line_item_description_prompt: str = (
+        "Write a short description for invoice line item '{item_name}'."
+    )
 
 
 class GeneratorCfg(BaseModel):
@@ -38,29 +42,6 @@ class RuntimeConfig(BaseModel):
     force_no_tax: bool = False
 
 
-_DEFAULT_YAML = """\
-ai:
-  enabled: true
-  model: gpt-4o-mini
-  temperature: 0.15
-  top_p: 1.0
-  max_output_tokens: 1200
-  system_prompt:
-  max_vendors: 6
-
-generator:
-  allow_price_variation: false
-  price_variation_pct: 0.10
-  currency: AUD
-  status: AUTHORISED
-  business_days_only: true
-
-artifacts:
-  include_meta_json: true
-force_no_tax: false
-"""
-
-
 def _config_dir(base_dir: str) -> Path:
     p = Path(base_dir) / "config"
     p.mkdir(parents=True, exist_ok=True)
@@ -76,15 +57,15 @@ def _defaults_path(base_dir: str) -> Path:
     return _config_dir(base_dir) / "service_defaults.yaml"
 
 
-def _load_yaml(path: Path) -> Dict[str, Any]:
+def _load_yaml(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {}
-    with open(path, "r", encoding="utf-8") as f:
+    with open(path, encoding="utf-8") as f:
         data = yaml.safe_load(f)
     return data or {}
 
 
-def _deep_merge(a: Dict[str, Any], b: Dict[str, Any]) -> Dict[str, Any]:
+def _deep_merge(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
     out = dict(a)
     for k, v in b.items():
         if isinstance(v, dict) and isinstance(out.get(k), dict):
@@ -95,18 +76,13 @@ def _deep_merge(a: Dict[str, Any], b: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def load_runtime_config(base_dir: str) -> RuntimeConfig:
-    runtime_path = _runtime_path(base_dir)
-    if not runtime_path.exists():
-        runtime_path.write_text(_DEFAULT_YAML, encoding="utf-8")
-
-    defaults = _load_yaml(_defaults_path(base_dir))   # may be {}
-    runtime = _load_yaml(runtime_path)
-
+    defaults = _load_yaml(_defaults_path(base_dir))
+    runtime = _load_yaml(_runtime_path(base_dir))
     merged = _deep_merge(defaults, runtime)
     return RuntimeConfig(**merged)
 
 
-def save_runtime_config(cfg: RuntimeConfig, base_dir: Optional[str] = None) -> None:
+def save_runtime_config(cfg: RuntimeConfig, base_dir: str | None = None) -> None:
     base_dir = base_dir or settings.data_dir
     runtime_path = _runtime_path(base_dir)
     raw = cfg.model_dump()

--- a/src/synthap/engine/generator.py
+++ b/src/synthap/engine/generator.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
-from dataclasses import dataclass
-from decimal import Decimal, ROUND_HALF_UP
-from typing import List, Optional
-from datetime import date, timedelta
+
 import random
+from dataclasses import dataclass
+from datetime import date, timedelta
+from decimal import ROUND_HALF_UP, Decimal
+
 from slugify import slugify
 
-from ..catalogs.loader import Catalogs, Vendor, Item
-from .planner import business_days, calc_due_date
+from ..ai.descriptions import generate_line_description
 from ..ai.schema import Plan, VendorPlan
+from ..catalogs.loader import Catalogs, Item, Vendor
+from .planner import business_days, calc_due_date
 
 Money = Decimal
+
 
 @dataclass
 class InvoiceLine:
@@ -22,35 +25,42 @@ class InvoiceLine:
     line_amount: Money
     item_code: str
 
+
 @dataclass
 class Invoice:
     vendor_id: str
     contact_id: str
-    contact_account_number: Optional[str]
+    contact_account_number: str | None
     date: date
     due_date: date
     currency: str
     status: str
     reference: str
     invoice_number: str
-    lines: List[InvoiceLine]
+    lines: list[InvoiceLine]
+
 
 def q2(v: float | Decimal) -> Money:
-    return (Decimal(v).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
+    return Decimal(v).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
 
 def _qty_for_item(code: str, rng: random.Random) -> int:
     cl = code.lower()
-    if "lab" in cl or "hour" in cl: return rng.randint(1, 8)
-    if any(x in cl for x in ["water", "fence", "scaf", "hire", "pump"]): return rng.randint(1, 40)
+    if "lab" in cl or "hour" in cl:
+        return rng.randint(1, 8)
+    if any(x in cl for x in ["water", "fence", "scaf", "hire", "pump"]):
+        return rng.randint(1, 40)
     return rng.randint(1, 12)
 
-def _items_for_vendor(cat: Catalogs, vendor: Vendor) -> List[Item]:
+
+def _items_for_vendor(cat: Catalogs, vendor: Vendor) -> list[Item]:
     codes = cat.vendor_items.get(vendor.id, [])
     by_code = {i.code: i for i in cat.items}
     items = [by_code[c] for c in codes if c in by_code]
     return items if items else cat.items  # fallback
 
-def _pick_lines(items: List[Item], vp: VendorPlan, rng: random.Random) -> List[Item]:
+
+def _pick_lines(items: list[Item], vp: VendorPlan, rng: random.Random) -> list[Item]:
     n = rng.randint(vp.min_lines_per_invoice, vp.max_lines_per_invoice)
     # prefer unique items if enough available, otherwise allow repeats
     if len(items) >= n:
@@ -58,27 +68,39 @@ def _pick_lines(items: List[Item], vp: VendorPlan, rng: random.Random) -> List[I
     # not enough distinct items; allow repetition
     return [rng.choice(items) for _ in range(n)]
 
+
 def generate_from_plan(
     cat: Catalogs,
     plan: Plan,
     run_id: str,
     seed: int,
     force_no_tax: bool = False,
-) -> List[Invoice]:
+    cfg=None,
+) -> list[Invoice]:
+    if cfg is None:
+        try:
+            from ..config.runtime_config import load_runtime_config
+            from ..config.settings import settings
+
+            cfg = load_runtime_config(settings.data_dir)
+        except Exception:  # pragma: no cover - fallback when config can't load
+            cfg = None
     rng = random.Random(seed)
 
     # build date universe (business days or all days)
     if plan.business_days_only:
         days = business_days(plan.date_range.start, plan.date_range.end)
     else:
-        days = [plan.date_range.start + timedelta(days=i)
-                for i in range((plan.date_range.end - plan.date_range.start).days + 1)]
+        days = [
+            plan.date_range.start + timedelta(days=i)
+            for i in range((plan.date_range.end - plan.date_range.start).days + 1)
+        ]
     if not days:
         raise ValueError("No days in period.")
 
-    invoices: List[Invoice] = []
+    invoices: list[Invoice] = []
     vendors_by_id = {v.id: v for v in cat.vendors}
-    items_by_vendor_cache: dict[str, List[Item]] = {}
+    items_by_vendor_cache: dict[str, list[Item]] = {}
 
     seq = 0
     inv_seq_by_vendor: dict[str, int] = {}
@@ -96,26 +118,43 @@ def generate_from_plan(
             due = calc_due_date(issue, vendor)
             chosen_item_objs = _pick_lines(vend_items, vp, rng)
 
-            lines: List[InvoiceLine] = []
+            lines: list[InvoiceLine] = []
             for it in chosen_item_objs:
                 qty = _qty_for_item(it.code, rng)
-                unit = q2(it.unit_price) if not plan.allow_price_variation else q2(
-                    it.unit_price * (1 + (rng.random()*2-1) * float(plan.price_variation_pct or 0.0))
+                unit = (
+                    q2(it.unit_price)
+                    if not plan.allow_price_variation
+                    else q2(
+                        it.unit_price
+                        * (
+                            1
+                            + (rng.random() * 2 - 1)
+                            * float(plan.price_variation_pct or 0.0)
+                        )
+                    )
                 )
                 line_amt = q2(Decimal(qty) * unit)
                 tax_code = "EXEMPTEXPENSES" if force_no_tax else it.tax_code
-                lines.append(InvoiceLine(
-                    description=it.name,
-                    quantity=Decimal(qty),
-                    unit_amount=unit,
-                    account_code=it.account_code,
-                    tax_type=tax_code,
-                    line_amount=line_amt,
-                    item_code=it.code,
-                ))
+                desc = it.name
+                if cfg and cfg.ai.enabled and cfg.ai.line_item_description_enabled:
+                    desc = generate_line_description(it.name, cfg.ai)
+                lines.append(
+                    InvoiceLine(
+                        description=desc,
+                        quantity=Decimal(qty),
+                        unit_amount=unit,
+                        account_code=it.account_code,
+                        tax_type=tax_code,
+                        line_amount=line_amt,
+                        item_code=it.code,
+                    )
+                )
 
-            ref_suffix = "".join(rng.choice("ABCDEFGHJKLMNPQRSTUVWXYZ23456789") for _ in range(4))
-            reference = f"AP-{run_id[:6]}-{slugify(vendor.name)[:10].upper()}-{seq:04d}-{ref_suffix}"
+            ref_suffix = "".join(
+                rng.choice("ABCDEFGHJKLMNPQRSTUVWXYZ23456789") for _ in range(4)
+            )
+            vendor_slug = slugify(vendor.name)[:10].upper()
+            reference = f"AP-{run_id[:6]}-{vendor_slug}-{seq:04d}-{ref_suffix}"
 
             inv_seq = inv_seq_by_vendor.get(vendor.id)
             if inv_seq is None:
@@ -125,23 +164,27 @@ def generate_from_plan(
             prefix = vendor.id.replace("VEND-", "")
             invoice_number = f"{prefix}-{issue.year}{issue.month:02d}-{inv_seq:04d}"
 
-            invoices.append(Invoice(
-                vendor_id=vendor.id,
-                contact_id=vendor.xero_contact_id,
-                contact_account_number=getattr(vendor, "xero_account_number", None),
-                date=issue,
-                due_date=due,
-                currency=plan.currency or "AUD",
-                status=plan.status or "AUTHORISED",
-                reference=reference,
-                invoice_number=invoice_number,
-                lines=lines,
-            ))
+            invoices.append(
+                Invoice(
+                    vendor_id=vendor.id,
+                    contact_id=vendor.xero_contact_id,
+                    contact_account_number=getattr(vendor, "xero_account_number", None),
+                    date=issue,
+                    due_date=due,
+                    currency=plan.currency or "AUD",
+                    status=plan.status or "AUTHORISED",
+                    reference=reference,
+                    invoice_number=invoice_number,
+                    lines=lines,
+                )
+            )
 
     while len(invoices) < plan.total_count and plan.vendor_mix:
         vp = plan.vendor_mix[0]
         vendor = vendors_by_id[vp.vendor_id]
-        vend_items = items_by_vendor_cache.get(vendor.id) or _items_for_vendor(cat, vendor)
+        vend_items = items_by_vendor_cache.get(vendor.id) or _items_for_vendor(
+            cat, vendor
+        )
         seq += 1
         issue = rng.choice(days)
         due = calc_due_date(issue, vendor)
@@ -152,9 +195,25 @@ def generate_from_plan(
             unit = q2(it.unit_price)
             line_amt = q2(Decimal(qty) * unit)
             tax_code = "EXEMPTEXPENSES" if force_no_tax else it.tax_code
-            lines.append(InvoiceLine(it.name, Decimal(qty), unit, it.account_code, tax_code, line_amt, it.code))
-        ref_suffix = "".join(rng.choice("ABCDEFGHJKLMNPQRSTUVWXYZ23456789") for _ in range(4))
-        reference = f"AP-{run_id[:6]}-{slugify(vendor.name)[:10].upper()}-{seq:04d}-{ref_suffix}"
+            desc = it.name
+            if cfg and cfg.ai.enabled and cfg.ai.line_item_description_enabled:
+                desc = generate_line_description(it.name, cfg.ai)
+            lines.append(
+                InvoiceLine(
+                    desc,
+                    Decimal(qty),
+                    unit,
+                    it.account_code,
+                    tax_code,
+                    line_amt,
+                    it.code,
+                )
+            )
+        ref_suffix = "".join(
+            rng.choice("ABCDEFGHJKLMNPQRSTUVWXYZ23456789") for _ in range(4)
+        )
+        vendor_slug = slugify(vendor.name)[:10].upper()
+        reference = f"AP-{run_id[:6]}-{vendor_slug}-{seq:04d}-{ref_suffix}"
         inv_seq = inv_seq_by_vendor.get(vendor.id)
         if inv_seq is None:
             inv_seq = rng.randint(1000, 9999)


### PR DESCRIPTION
## Summary
- allow configuring AI to write realistic line item descriptions
- add OpenAI-powered `generate_line_description` utility
- document how to enable and use the feature
- pull runtime configuration from `data/config` YAML files instead of embedded defaults

## Testing
- `ruff check src/synthap/config/runtime_config.py src/synthap/ai/descriptions.py src/synthap/engine/generator.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6a515680c8320b27694cf4b7c565e