### PR TITLE
Add payment generator and payment posting to Xero

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,21 @@ runtime. When enabled the generator will call OpenAI to craft a natural
 description for each line item while keeping it consistent with the catalog's
 item name.
 
+## Invoice insertion and payment reports
+
+Run `synthap generate` to stage invoices and `synthap insert` to post them to
+Xero. After insertion the application writes several JSON reports to the run
+directory (`runs/<run_id>`):
+
+- `insertion_report.json` – summary counts of inserted invoices and payments
+  made.
+- `invoice_report.json` – raw invoice records returned by the Xero Invoices
+  API, including the assigned `InvoiceID` values.
+- `payment_report.json` – raw payment records returned by the Xero Payments
+  API.
+
+The generator can understand phrases like "pay for 4 bills" or "pay for all"
+in the NLP query and will automatically create and submit corresponding payment
+payloads. The Xero account used for payments is configured via the
+`XERO_PAYMENT_ACCOUNT_CODE` setting.
+

--- a/src/synthap/cli.py
+++ b/src/synthap/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import secrets
+import json
 from pathlib import Path
 from datetime import date
 from typing import Optional
@@ -9,6 +10,7 @@ from typing import Optional
 import pandas as pd
 import typer
 from slugify import slugify
+from tenacity import RetryError
 
 from .config.settings import settings
 from .config.runtime_config import load_runtime_config
@@ -24,10 +26,12 @@ from .engine.validators import validate_invoices
 from .data.storage import to_rows, write_parquet
 from .reports.report import write_json
 from .xero.mapper import map_invoice
+from .nlp.parser import parse_nlp_to_query
 
 # Xero (OAuth + client)
 from .xero.auth_server import run_server as auth_server_run
-from .xero.client import post_invoices, resolve_tenant_id
+from .xero.client import post_invoices, resolve_tenant_id, post_payments
+from .engine.payments import generate_payments
 from .xero.oauth import TokenStore, refresh_token_if_needed
 
 app = typer.Typer(add_completion=False)
@@ -105,6 +109,7 @@ def generate(
 
     # 1) AI plan (with built-in guardrails + AU fiscal periods)
     plan: AIPlan = plan_from_query(query, cat, today=date.today())
+    parsed_query = parse_nlp_to_query(query, today=date.today())
 
     # Apply CLI overrides (final say)
     if allow_price_variation is not None:
@@ -182,6 +187,10 @@ def generate(
             "currency": plan.currency,
             "status": plan.status,
             "business_days_only": plan.business_days_only,
+        },
+        "payment_instructions": {
+            "count": parsed_query.pay_count,
+            "all": parsed_query.pay_all,
         },
     }
     write_json(gen_report, base / "generation_report.json")
@@ -263,32 +272,51 @@ def insert(
                 total_ok += len(batch_invoices)
                 for inv in batch_invoices:
                     ref = inv.get("Reference")
-                    vendor = None
                     if ref is not None:
                         match = inv_df[inv_df["reference"] == ref]
                         if not match.empty:
-                            vendor = match.iloc[0].get("vendor_id")
-                    invoice_records.append(
-                        {
-                            "InvoiceID": inv.get("InvoiceID"),
-                            "InvoiceNumber": inv.get("InvoiceNumber"),
-                            "Vendor": vendor,
-                            "Date": inv.get("Date"),
-                            "DueDate": inv.get("DueDate"),
-                            "Total": inv.get("Total"),
-                            "AmountDue": inv.get("AmountDue"),
-                        }
-                    )
+                            inv["Vendor"] = match.iloc[0].get("vendor_id")
+                    invoice_records.append(inv)
             except Exception as e:
                 total_fail += len(batch)
                 typer.echo(f"Batch {i//batch_size} failed: {e}")
+        pay_count = None
+        pay_all = False
+        gen_report_path = base / "generation_report.json"
+        if gen_report_path.exists():
+            try:
+                pay_info = json.loads(gen_report_path.read_text()).get("payment_instructions", {})
+                pay_count = pay_info.get("count")
+                pay_all = bool(pay_info.get("all"))
+            except Exception:
+                pass
+        payments = generate_payments(
+            invoice_records,
+            pay_count=pay_count,
+            pay_all=pay_all,
+            account_code=settings.xero_payment_account_code,
+        )
+        payment_records = []
+        if payments:
+            try:
+                resp = await post_payments(payments)
+                payment_records = resp.get("Payments", [])
+                typer.echo(f"[{run_id}] Paid {len(payment_records)} invoices.")
+            except RetryError as e:
+                typer.echo(f"Payment batch failed: {e.last_attempt.exception()}")
+            except Exception as e:
+                typer.echo(f"Payment batch failed: {e}")
+        else:
+            typer.echo(f"[{run_id}] No payments generated.")
         report = {
             "run_id": run_id,
             "inserted_success": total_ok,
             "inserted_failed": total_fail,
+            "payments_made": len(payment_records),
         }
         write_json(report, base / "insertion_report.json")
-        write_json(invoice_records, base / "invoice_report.json")
+        write_json({"run_id": run_id, "invoices": invoice_records}, base / "invoice_report.json")
+        write_json({"run_id": run_id, "payments": payment_records}, base / "payment_report.json")
         typer.echo(f"[{run_id}] Inserted: {total_ok}, Failed: {total_fail}. Report saved.")
 
     asyncio.run(_insert())

--- a/src/synthap/config/settings.py
+++ b/src/synthap/config/settings.py
@@ -13,6 +13,7 @@ class Settings(BaseSettings):
     xero_redirect_uri: str = Field(alias="XERO_REDIRECT_URI")
     xero_scopes: str = Field(alias="XERO_SCOPES")
     xero_tenant_id: Optional[str] = Field(alias="XERO_TENANT_ID", default=None)
+    xero_payment_account_code: str = Field(alias="XERO_PAYMENT_ACCOUNT_CODE", default="001")
 
     # Service
     timezone: str = Field(default="Australia/Melbourne", alias="TIMEZONE")

--- a/src/synthap/engine/payments.py
+++ b/src/synthap/engine/payments.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from datetime import date
+import random
+from typing import List, Dict, Any, Optional
+
+
+def generate_payments(
+    invoice_records: List[Dict[str, Any]],
+    pay_count: Optional[int] = None,
+    pay_all: bool = False,
+    account_code: str | None = None,
+    payment_date: Optional[date] = None,
+    rng: Optional[random.Random] = None,
+) -> List[Dict[str, Any]]:
+    """Create Xero payment payloads for a subset of invoices.
+
+    If ``pay_all`` is True all invoices will be paid. Otherwise a subset
+    determined by ``pay_count`` (or a random count if None) is selected.
+    """
+    if not invoice_records:
+        return []
+    if rng is None:
+        rng = random.Random()
+    if account_code is None:
+        account_code = "001"
+    if payment_date is None:
+        payment_date = date.today()
+
+    records = invoice_records
+    if not pay_all:
+        if pay_count is None:
+            pay_count = rng.randint(0, len(records))
+        pay_count = max(0, min(pay_count, len(records)))
+        records = rng.sample(records, pay_count) if pay_count else []
+
+    payments: List[Dict[str, Any]] = []
+    for rec in records:
+        inv_id = rec.get("InvoiceID")
+        amount = rec.get("AmountDue") or rec.get("Total")
+        if not inv_id or amount is None:
+            continue
+        payments.append(
+            {
+                "Invoice": {"InvoiceID": inv_id},
+                "Account": {"Code": account_code},
+                "Date": payment_date.isoformat(),
+                "Amount": amount,
+            }
+        )
+    return payments

--- a/src/synthap/xero/client.py
+++ b/src/synthap/xero/client.py
@@ -69,3 +69,26 @@ async def post_invoices(invoices: List[Dict[str, Any]]) -> Dict[str, Any]:
         if r.status_code >= 400:
             _raise_with_context(r)
         return r.json()
+
+
+@retry(wait=wait_exponential_jitter(1, 3), stop=stop_after_attempt(5))
+async def post_payments(payments: List[Dict[str, Any]]) -> Dict[str, Any]:
+    tok = TokenStore.load()
+    if not tok:
+        tok = await refresh_token_if_needed()
+
+    tenant_id = await resolve_tenant_id(tok)
+    headers = _with_tenant(_auth_headers(tok), tenant_id)
+    payload = {"Payments": payments}
+
+    async with httpx.AsyncClient(timeout=60) as client:
+        r = await client.post(f"{XERO_BASE}/Payments", json=payload, headers=headers)
+        if r.status_code == 401:
+            tok = await refresh_token_if_needed()
+            tenant_id = await resolve_tenant_id(tok)
+            r = await client.post(
+                f"{XERO_BASE}/Payments", json=payload, headers=_with_tenant(_auth_headers(tok), tenant_id)
+            )
+        if r.status_code >= 400:
+            _raise_with_context(r)
+        return r.json()

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -1,0 +1,161 @@
+from datetime import date
+import json
+import random
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pandas as pd
+
+from synthap.nlp.parser import parse_nlp_to_query
+from synthap.engine.payments import generate_payments
+
+
+def test_parse_pay_count():
+    pq = parse_nlp_to_query(
+        "Generate 10 bills for Q1 2024 and pay for 4 bills",
+        today=date(2024, 1, 1),
+    )
+    assert pq.total_count == 10
+    assert pq.pay_count == 4
+    assert not pq.pay_all
+
+
+def test_parse_pay_all():
+    pq = parse_nlp_to_query(
+        "Generate 10 bills for Q1 2024 and pay for all",
+        today=date(2024, 1, 1),
+    )
+    assert pq.pay_all is True
+
+
+def test_generate_payments_selection():
+    invoices = [
+        {"InvoiceID": "1", "AmountDue": 100},
+        {"InvoiceID": "2", "AmountDue": 200},
+        {"InvoiceID": "3", "AmountDue": 300},
+    ]
+    payments = generate_payments(
+        invoices,
+        pay_count=1,
+        pay_all=False,
+        account_code="001",
+        payment_date=date(2024, 1, 1),
+        rng=random.Random(0),
+    )
+    assert len(payments) == 1
+    assert payments[0]["Invoice"]["InvoiceID"] in {"1", "2", "3"}
+    assert payments[0]["Account"]["Code"] == "001"
+    assert payments[0]["Date"] == "2024-01-01"
+
+
+def test_generate_payments_all():
+    invoices = [
+        {"InvoiceID": "1", "AmountDue": 100},
+        {"InvoiceID": "2", "AmountDue": 200},
+    ]
+    payments = generate_payments(
+        invoices,
+        pay_count=None,
+        pay_all=True,
+        account_code="001",
+        payment_date=date(2024, 1, 1),
+    )
+    assert len(payments) == 2
+    ids = {p["Invoice"]["InvoiceID"] for p in payments}
+    assert ids == {"1", "2"}
+
+
+def test_insert_writes_reports_with_xero_data(tmp_path, monkeypatch):
+    import types, sys, synthap
+    import synthap.config
+
+    fake_settings = types.ModuleType("synthap.config.settings")
+
+    class DummySettings:
+        runs_dir = str(tmp_path)
+        xero_payment_account_code = "001"
+
+    fake_settings.settings = DummySettings()
+    sys.modules["synthap.config.settings"] = fake_settings
+
+    sys.modules.pop("pydantic", None)
+    import pydantic  # reload real module
+
+    from synthap import cli
+
+    base = tmp_path / "run1"
+    base.mkdir()
+
+    inv_df = pd.DataFrame(
+        [
+            {
+                "reference": "ABC",
+                "contact_id": "c1",
+                "currency": "USD",
+                "date": "2024-01-01",
+                "due_date": "2024-01-31",
+                "status": "AUTHORISED",
+                "vendor_id": "v1",
+            }
+        ]
+    )
+    inv_df.to_parquet(base / "invoices.parquet", index=False)
+
+    line_df = pd.DataFrame(
+        [
+            {
+                "reference": "ABC",
+                "description": "Item",
+                "quantity": 1,
+                "unit_amount": 100,
+                "account_code": "200",
+                "tax_type": "NONE",
+                "line_amount": 100,
+            }
+        ]
+    )
+    line_df.to_parquet(base / "invoice_lines.parquet", index=False)
+
+    (base / "generation_report.json").write_text(
+        json.dumps({"payment_instructions": {"count": 1}})
+    )
+
+    monkeypatch.setattr(cli.settings, "runs_dir", str(tmp_path))
+
+    async def fake_post_invoices(batch):
+        return {
+            "Invoices": [
+                {
+                    "InvoiceID": "inv1",
+                    "InvoiceNumber": "INV-1",
+                    "Reference": "ABC",
+                    "AmountDue": 100.0,
+                }
+            ]
+        }
+
+    async def fake_post_payments(payments):
+        return {
+            "Payments": [
+                {
+                    "PaymentID": "pay1",
+                    "Invoice": {"InvoiceID": "inv1"},
+                    "Amount": 100.0,
+                }
+            ]
+        }
+
+    monkeypatch.setattr(cli, "post_invoices", fake_post_invoices)
+    monkeypatch.setattr(cli, "post_payments", fake_post_payments)
+
+    cli.insert(run_id="run1", reference=None, limit=None)
+
+    inv_report = json.loads((base / "invoice_report.json").read_text())
+    pay_report = json.loads((base / "payment_report.json").read_text())
+
+    assert inv_report["run_id"] == "run1"
+    assert inv_report["invoices"][0]["InvoiceID"] == "inv1"
+    assert pay_report["run_id"] == "run1"
+    assert pay_report["payments"][0]["PaymentID"] == "pay1"

--- a/tests/test_xero_client.py
+++ b/tests/test_xero_client.py
@@ -1,0 +1,55 @@
+import asyncio
+import httpx
+import sys
+from pathlib import Path
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+fake_settings = types.ModuleType("synthap.config.settings")
+
+
+class DummySettings:
+    xero_tenant_id = None
+    xero_payment_account_code = "001"
+
+
+fake_settings.settings = DummySettings()
+sys.modules["synthap.config.settings"] = fake_settings
+
+from synthap.xero import client as xc
+
+
+def test_post_payments_uses_post(monkeypatch):
+    called = {}
+
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def post(self, url, json, headers):
+            called['method'] = 'POST'
+            return httpx.Response(200, json={"Payments": []})
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **kw: DummyClient())
+    monkeypatch.setattr(xc.TokenStore, "load", staticmethod(lambda: {"access_token": "tok"}))
+
+    async def fake_resolve(tok):
+        return "tenant"
+
+    monkeypatch.setattr(xc, "resolve_tenant_id", fake_resolve)
+
+    payments = [
+        {
+            "Invoice": {"InvoiceID": "1"},
+            "Account": {"Code": "001"},
+            "Date": "2024-01-01",
+            "Amount": 10,
+        }
+    ]
+
+    asyncio.run(xc.post_payments(payments))
+    assert called.get('method') == 'POST'


### PR DESCRIPTION
## Summary
- parse NLP queries for payment instructions
- generate payment payloads and send payments to Xero using correct HTTP method
- record full Xero invoice and payment responses in run reports
- add tests for payment parsing, generation, and reporting
- add regression test confirming payments are posted via POST

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a80f70d18083209bac29cf03284f6e