### PR TITLE
Validate NLP query scope with optional LLM parsing

### DIFF
--- a/src/synthap/ai/planner.py
+++ b/src/synthap/ai/planner.py
@@ -88,7 +88,7 @@ def plan_from_query(query: str, cat: Catalogs, today: date) -> Plan:
 
     if not cfg.ai.enabled:
         from ..nlp.parser import parse_nlp_to_query
-        pq = parse_nlp_to_query(query, today=today)
+        pq = parse_nlp_to_query(query, today=today, catalogs=cat, use_llm=True)
         start, end = pq.date_range.start, pq.date_range.end
         total = pq.total_count or total_fallback
         # spread across up to max_vendors
@@ -171,7 +171,7 @@ def plan_from_query(query: str, cat: Catalogs, today: date) -> Plan:
     except Exception as e:
         # Hard fallback on any JSON/validation error
         from ..nlp.parser import parse_nlp_to_query
-        pq = parse_nlp_to_query(query, today=today)
+        pq = parse_nlp_to_query(query, today=today, catalogs=cat, use_llm=True)
         start, end = pq.date_range.start, pq.date_range.end
         total = pq.total_count or total_fallback
         take = min(cfg.ai.max_vendors, len(cat.vendors))

--- a/src/synthap/cli.py
+++ b/src/synthap/cli.py
@@ -112,7 +112,7 @@ def generate(
 
     # 1) AI plan (with built-in guardrails + AU fiscal periods)
     plan: AIPlan = plan_from_query(query, cat, today=date.today())
-    parsed_query = parse_nlp_to_query(query, today=date.today())
+    parsed_query = parse_nlp_to_query(query, today=date.today(), catalogs=cat, use_llm=True)
 
     # Apply CLI overrides (final say)
     if allow_price_variation is not None:

--- a/src/synthap/nlp/parser.py
+++ b/src/synthap/nlp/parser.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
+import json
 import re
 from dataclasses import dataclass
 from datetime import date
 from typing import Optional
 
 from .periods import resolve_period_au  # AU fiscal / common phrases
+from ..catalogs.loader import Catalogs
+import os
+
+
+class QueryScopeError(ValueError):
+    """Raised when the user's request refers to unknown catalog entries."""
 
 @dataclass
 class ParsedQueryDateRange:
@@ -24,9 +31,9 @@ class ParsedQuery:
     pay_all: bool = False
 
 COUNT_PATTERNS = [
-    r"\bgenerate\s+(\d+)\b",
-    r"\bneed\s+(\d+)\b",
-    r"\b(\d+)\s+(?:bills|invoices)\b",
+    r"\bgenerate\s+(\d+(?:\.\d+)?)\b",
+    r"\bneed\s+(\d+(?:\.\d+)?)\b",
+    r"\b(\d+(?:\.\d+)?)\s+(?:bills|invoices)\b",
 ]
 
 VENDOR_PATTERNS = [
@@ -42,12 +49,12 @@ LINE_RANGE_PATTERNS = [
 ]
 
 PAY_COUNT_PATTERNS = [
-    r"pay for only (\d+)",
-    r"pay only (\d+)",
-    r"pay for (\d+) bills?",
-    r"pay (\d+) bills?",
-    r"pay for (\d+)",
-    r"pay (\d+)",
+    r"pay for only (\d+(?:\.\d+)?)",
+    r"pay only (\d+(?:\.\d+)?)",
+    r"pay for (\d+(?:\.\d+)?) bills?",
+    r"pay (\d+(?:\.\d+)?) bills?",
+    r"pay for (\d+(?:\.\d+)?)",
+    r"pay (\d+(?:\.\d+)?)",
 ]
 
 PAY_ALL_PATTERNS = [
@@ -56,14 +63,59 @@ PAY_ALL_PATTERNS = [
     r"pay every(thing| bill)",
 ]
 
+
+def _ensure_int(value: Optional[object]) -> Optional[int]:
+    """Convert a value to int if possible, validating integers."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError("Invalid number 'bool'")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if value.is_integer():
+            return int(value)
+        raise ValueError(f"Invalid non-integer number '{value}'")
+    if isinstance(value, str):
+        if value.strip().isdigit():
+            return int(value)
+        raise ValueError(f"Invalid number '{value}'")
+    raise ValueError(f"Invalid number '{value}'")
+
+
+def _parse_with_llm(text: str, api_key: str) -> dict:
+    """Use an LLM to extract structured fields from the query."""
+    from openai import OpenAI
+
+    client = OpenAI(api_key=api_key)
+    system = (
+        "You parse accounts payable generation requests and extract"\
+        " fields. Return JSON with keys: total_count, vendor_name,"\
+        " min_lines_per_invoice, max_lines_per_invoice, pay_count, pay_all."
+    )
+    user = {"query": text}
+    resp = client.chat.completions.create(
+        model="gpt-4o-mini",
+        temperature=0,
+        response_format={"type": "json_object"},
+        messages=[
+            {"role": "system", "content": system},
+            {"role": "user", "content": json.dumps(user)},
+        ],
+    )
+    return json.loads(resp.choices[0].message.content)
+
 def _extract_int(patterns: list[str], text: str) -> Optional[int]:
     for p in patterns:
         m = re.search(p, text, flags=re.IGNORECASE)
         if m:
+            s = m.group(1)
+            if "." in s:
+                raise ValueError(f"Invalid non-integer number '{s}'")
             try:
-                return int(m.group(1))
+                return int(s)
             except ValueError:
-                pass
+                raise ValueError(f"Invalid number '{s}'")
     return None
 
 def _extract_vendor(text: str) -> Optional[str]:
@@ -92,20 +144,91 @@ def _extract_pay_info(text: str) -> tuple[Optional[int], bool]:
     all_flag = any(re.search(p, text, flags=re.IGNORECASE) for p in PAY_ALL_PATTERNS)
     return count, all_flag
 
-def parse_nlp_to_query(text: str, today: date) -> ParsedQuery:
+def parse_nlp_to_query(
+    text: str,
+    today: date,
+    catalogs: Catalogs | None = None,
+    use_llm: bool = False,
+) -> ParsedQuery:
     t = text.strip()
-    count = _extract_int(COUNT_PATTERNS, t) or 10
+
+    llm_data = None
+    api_key = os.getenv("OPENAI_API_KEY")
+    if use_llm and api_key:
+        try:
+            llm_data = _parse_with_llm(t, api_key)
+        except Exception:
+            llm_data = None
+
+    count = _ensure_int(llm_data.get("total_count")) if llm_data else None
+    if count is None:
+        count = _extract_int(COUNT_PATTERNS, t) or 10
+
+    if count <= 0:
+        raise ValueError("Bill count must be a positive integer")
 
     # AU-aware period resolver (handles 'Q1 2025', 'last quarter', 'yesterday', etc.)
     dr = resolve_period_au(t, today=today)
 
-    vendor_name = _extract_vendor(t)
-    min_lines, max_lines = _extract_line_range(t)
-    pay_count, pay_all = _extract_pay_info(t)
+    vendor_name = llm_data.get("vendor_name") if llm_data else None
+    if not vendor_name:
+        vendor_name = _extract_vendor(t)
+
+    vendor_id = None
+    if catalogs and vendor_name:
+        name_map = {v.name.lower(): v for v in catalogs.vendors}
+        v = name_map.get(vendor_name.lower())
+        if not v:
+            raise QueryScopeError(f"Query out of scope: unknown vendor '{vendor_name}'")
+        item_codes = catalogs.vendor_items.get(v.id, [])
+        if not item_codes:
+            raise QueryScopeError(
+                f"Query out of scope: vendor '{vendor_name}' has no items"
+            )
+        item_map = {i.code: i for i in catalogs.items}
+        account_codes = {a.code for a in catalogs.accounts}
+        tax_codes = {t.code for t in catalogs.tax_codes}
+        for code in item_codes:
+            it = item_map.get(code)
+            if not it:
+                raise QueryScopeError(
+                    f"Query out of scope: unknown item '{code}' for vendor '{vendor_name}'"
+                )
+            if it.account_code not in account_codes:
+                raise QueryScopeError(
+                    f"Query out of scope: item '{code}' missing account '{it.account_code}'"
+                )
+            if it.tax_code not in tax_codes:
+                raise QueryScopeError(
+                    f"Query out of scope: item '{code}' missing tax code '{it.tax_code}'"
+                )
+        vendor_id = v.id
+
+    if llm_data:
+        min_lines = _ensure_int(llm_data.get("min_lines_per_invoice"))
+        max_lines = _ensure_int(llm_data.get("max_lines_per_invoice"))
+        pay_count = _ensure_int(llm_data.get("pay_count"))
+        pay_all = bool(llm_data.get("pay_all"))
+    else:
+        min_lines = max_lines = pay_count = None
+        pay_all = False
+
+    if min_lines is None or max_lines is None:
+        lr_min, lr_max = _extract_line_range(t)
+        if min_lines is None:
+            min_lines = lr_min
+        if max_lines is None:
+            max_lines = lr_max
+
+    if pay_count is None:
+        pc, pa = _extract_pay_info(t)
+        pay_count = pc if pc is not None else pay_count
+        pay_all = pa or pay_all
 
     return ParsedQuery(
         total_count=count,
         date_range=ParsedQueryDateRange(start=dr.start, end=dr.end),
+        vendor_id=vendor_id,
         vendor_name=vendor_name,
         min_lines_per_invoice=min_lines,
         max_lines_per_invoice=max_lines,

--- a/tests/test_nlp_llm.py
+++ b/tests/test_nlp_llm.py
@@ -1,0 +1,31 @@
+from datetime import date
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+"""LLM parsing tests."""
+
+from synthap.catalogs.loader import load_catalogs
+from synthap.nlp import parser as parser_mod
+from synthap.nlp.parser import parse_nlp_to_query
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+
+
+def test_llm_parsing(monkeypatch):
+    def fake_llm(text: str, api_key: str) -> dict:
+        return {"total_count": 12, "vendor_name": "BuildRight Cement"}
+
+    monkeypatch.setattr(parser_mod, "_parse_with_llm", fake_llm)
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    cat = load_catalogs(str(DATA_DIR))
+    pq = parse_nlp_to_query(
+        "About a dozen bills for vendor BuildRight Cement in March 2024",
+        today=date(2024, 3, 1),
+        catalogs=cat,
+        use_llm=True,
+    )
+    assert pq.total_count == 12
+    assert pq.vendor_name == "BuildRight Cement"

--- a/tests/test_nlp_scope.py
+++ b/tests/test_nlp_scope.py
@@ -1,0 +1,48 @@
+from datetime import date
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pytest
+
+from synthap.catalogs.loader import load_catalogs
+from synthap.nlp.parser import parse_nlp_to_query, QueryScopeError
+
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+
+
+def _catalogs():
+    return load_catalogs(str(DATA_DIR))
+
+
+def test_unknown_vendor_triggers_out_of_scope():
+    cat = _catalogs()
+    with pytest.raises(QueryScopeError):
+        parse_nlp_to_query(
+            "Generate 10 bills for Q1 2024 for Vendor ABC",
+            today=date(2024, 1, 1),
+            catalogs=cat,
+        )
+
+
+def test_vendor_without_items_out_of_scope():
+    cat = _catalogs()
+    with pytest.raises(QueryScopeError):
+        parse_nlp_to_query(
+            "Generate 5 bills for 2024 for vendor No Contact",
+            today=date(2024, 1, 1),
+            catalogs=cat,
+        )
+
+
+def test_decimal_bill_count_invalid():
+    cat = _catalogs()
+    with pytest.raises(ValueError):
+        parse_nlp_to_query(
+            "Generate 10.1 bills for Q1 2024",
+            today=date(2024, 1, 1),
+            catalogs=cat,
+        )
+


### PR DESCRIPTION
## Summary
- add optional OpenAI-powered parser that extracts counts, vendor and line hints
- enable planner and CLI to invoke LLM parsing for richer query understanding
- add regression test exercising LLM-assisted parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac3b64ba648320b5a76e61d3ca766e