### PR TITLE
test: expand generator coverage and fix reference slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,96 +1,157 @@
 # Synthetic AP
 
-Synthetic AP generates realistic accounts payable invoices and optional payment
-records that can be inserted into Xero for demos or testing.
+Synthetic AP generates realistic accounts payable invoices and can insert them
+into a Xero sandbox for demos or testing.  The generator uses catalog data and
+optionally an OpenAI model to plan invoice mixes and craft line item
+descriptions.  Run artifacts and reports make it easy to audit the process or
+build further analytics.
 
-## Setup
+## Installation
 
-1. **Install dependencies**
+1. **Install Python 3.11**.
+2. **Install dependencies** using either Poetry or pip:
+
    ```bash
-   pip install -r requirements.txt  # or rely on the provided Poetry setup
+   # using Poetry (recommended)
+   poetry install
+
+   # or using pip
+   pip install -e .
    ```
-2. **Environment variables** – create a `.env` file or export the following:
-   - `XERO_CLIENT_ID`
-   - `XERO_CLIENT_SECRET`
-   - `XERO_REDIRECT_URI`
-   - `XERO_SCOPES`
-   - `XERO_PAYMENT_ACCOUNT_CODE` (defaults to `101`)
-   - `PAY_ON_DUE_DATE` (optional, default `false`)
 
+3. (Optional) install development dependencies with
+   `poetry install --with dev`.
 
-## Configuration
+## Environment variables
 
-Configuration lives under `data/config/`:
+Configuration values are read from environment variables or a `.env` file.  The
+most important settings are shown below:
 
-- **service_defaults.yaml** – baseline values committed to the repo
-- **runtime_config.yaml** – overrides applied on each run
+| Variable | Purpose |
+| --- | --- |
+| `OPENAI_API_KEY` | API key for OpenAI when LLM features are enabled. |
+| `XERO_CLIENT_ID`, `XERO_CLIENT_SECRET`, `XERO_REDIRECT_URI`, `XERO_SCOPES` | OAuth details for Xero. |
+| `XERO_TENANT_ID` | Xero tenant identifier (resolved after auth if omitted). |
+| `XERO_PAYMENT_ACCOUNT_CODE` | Account code used when posting payments (default `101`). |
+| `PAY_ON_DUE_DATE` | If `true`, date payments exactly on the invoice due date. |
+| `TIMEZONE`, `DEFAULT_SEED`, `FISCAL_YEAR_START_MONTH` | Optional service settings. |
+| `DATA_DIR` | Base directory for catalogs and configuration files. |
+| `RUNS_DIR` | Directory where run artifacts are written. |
+| `XERO_TOKEN_FILE` | Location of the OAuth token store. |
 
-Both files support these sections:
+All variables can be placed in a `.env` file in the project root.  See
+`src/synthap/config/settings.py` for the complete list of supported values.
+
+## Configuration files
+
+Runtime configuration lives under `data/config/` and is composed of two files:
+
+* `service_defaults.yaml` – repository defaults
+* `runtime_config.yaml` – local overrides applied at runtime
+
+The files are deep‑merged with runtime values taking precedence.  The structure
+supports the following sections:
 
 ```yaml
 ai:
-  model: gpt-4o-mini
-  line_item_description_enabled: true
+  enabled: true              # use the LLM for planning and descriptions
+  model: gpt-4o-mini         # OpenAI model name
+  temperature: 0.15
+  top_p: 1.0
+  max_output_tokens: 1200
+  max_vendors: 6
+  line_item_description_enabled: false
+  line_item_description_prompt: "Write a short description for invoice line item '{item_name}'."
 
 generator:
   allow_price_variation: false
-  price_variation_pct: 0.10
-  business_days_only: true
+  price_variation_pct: 0.10  # ±10% when variation enabled
+  currency: AUD
+  status: AUTHORISED
+  business_days_only: true   # only choose business days for invoice dates
+
+artifacts:
+  include_meta_json: true    # also save xero_invoices_with_meta.json
+
+force_no_tax: false
 
 payments:
-  pay_on_due_date: false   # pay exactly on the due date
-  allow_overdue: false     # if true and not paying on due date, pick a date after due
-  pay_when_unspecified: false  # if true, randomly pay some invoices even when the query has no pay directive
+  pay_on_due_date: false     # pay exactly on due date if true
+  allow_overdue: false       # if true and not paying on due date, allow payment after due
+  pay_when_unspecified: false # allow random payments when no directive in prompt
+```
+
+Edit `data/config/runtime_config.yaml` to customise behaviour.
 
 ## Workflow
 
-1. **Generate invoices**
-   ```bash
-   poetry run python -m synthap.cli generate -q "Generate 6 bills for the Q1 2023 pay for only 2"
-   ```
-   Options:
-   - `--seed` to make runs deterministic
-   - `--allow-price-variation/--no-price-variation`
-   - `--price-variance-pct` to override the percentage
+### 1. Authenticate with Xero
 
-   The command stages data under `runs/<run_id>/` including `to_pay.json` which
-   lists which invoices should be paid after insertion.
+```bash
+poetry run python -m synthap.cli auth-init
+```
 
-2. **Insert into Xero and pay**
-   ```bash
-   poetry run python -m synthap.cli insert --run-id <run_id>
-   ```
-   By default all staged invoices are inserted; use `--reference` or `--limit`
-   to filter. The command:
-   - posts invoices to the Xero Invoices API
-   - reloads `invoice_report.json` to capture `InvoiceID`s
-   - builds payment payloads for invoices listed in `to_pay.json`
-   - posts payments via the Xero Payments endpoint
+This launches a local server and prints an authorization URL.  After completing
+the OAuth consent flow the resulting token is saved (default: `.xero_token.json`).
+Verify the token and resolved tenant identifier with:
 
-3. **Inspect run artifacts** – each run directory contains:
-   - `invoice_report.json` – Xero invoice responses with IDs
-   - `payment_report.json` – Xero payment responses
-   - `xero_log.json` – chronological request/response log
-   - `insertion_report.json` – counts of invoices inserted and payments made
+```bash
+poetry run python -m synthap.cli xero-status
+```
 
-## Additional Commands
+### 2. Generate invoices
 
-- `poetry run python -m synthap.cli auth-init` – start a local server to obtain
-  OAuth tokens for Xero
-- `poetry run python -m synthap.cli xero-status` – verify token and tenant ID
+```bash
+poetry run python -m synthap.cli generate -q "Generate 6 bills for the Q1 2023 pay for only 2"
+```
+
+Useful options:
+
+* `--seed` – make runs deterministic
+* `--allow-price-variation/--no-price-variation` – override price variation
+* `--price-variance-pct` – set the variation percentage (e.g. `0.05` for ±5 %)
+
+Each invocation creates `runs/<run_id>/` containing:
+
+* `invoices.parquet`, `invoice_lines.parquet`
+* `plan.json` – LLM planning result
+* `xero_invoices.json` – Xero invoice payloads
+* `xero_invoices_with_meta.json` – payloads with extra metadata when enabled
+* `to_pay.json` – invoice references selected for payment
+* `generation_report.json` – summary report of the generation step
+
+### 3. Insert and optionally pay invoices
+
+```bash
+poetry run python -m synthap.cli insert --run-id <run_id>
+
+# limit the subset to insert
+poetry run python -m synthap.cli insert --run-id <run_id> --reference REF123 --limit 5
+```
+
+The command posts staged invoices to Xero and issues payments for references in
+`to_pay.json`.  Additional artifacts are written into the run directory:
+
+* `invoice_report.json` – responses from the Invoices API with invoice IDs
+* `payment_report.json` – responses from the Payments API
+* `xero_log.json` – chronological request/response log
+* `insertion_report.json` – counts of inserted invoices and payments
+
+## Inspecting results
+
+Run artifacts live under `runs/<run_id>/`.  They contain the generated invoice
+data, the exact payloads sent to Xero, receipts for invoices and payments, and a
+detailed log of API interactions.  Inspect the JSON or parquet files directly or
+load them into analytics tools for further analysis.
 
 ## Testing
 
-Run the test suite with:
+Execute the test suite with:
+
 ```bash
 pytest -q
 ```
 
-## Notes
+Running the tests ensures that configuration parsing, invoice generation and
+Xero integration helpers work as expected.
 
-Payment generation obeys NLP directives such as "pay for 4" or "pay for all".
-By default, no payments are made unless the NLP query includes a directive
-(`pay for 2`, `pay for all`, etc.). Set `payments.pay_when_unspecified: true`
-to allow random payments when no directive is provided. Payment dates are
-chosen within the invoice term unless `payments.allow_overdue` or
-`payments.pay_on_due_date` is set.

--- a/src/synthap/engine/generator.py
+++ b/src/synthap/engine/generator.py
@@ -153,7 +153,7 @@ def generate_from_plan(
             ref_suffix = "".join(
                 rng.choice("ABCDEFGHJKLMNPQRSTUVWXYZ23456789") for _ in range(4)
             )
-            vendor_slug = slugify(vendor.name)[:10].upper()
+            vendor_slug = slugify(vendor.name)[:10].rstrip("-").upper()
             reference = f"AP-{run_id[:6]}-{vendor_slug}-{seq:04d}-{ref_suffix}"
 
             inv_seq = inv_seq_by_vendor.get(vendor.id)
@@ -212,7 +212,7 @@ def generate_from_plan(
         ref_suffix = "".join(
             rng.choice("ABCDEFGHJKLMNPQRSTUVWXYZ23456789") for _ in range(4)
         )
-        vendor_slug = slugify(vendor.name)[:10].upper()
+        vendor_slug = slugify(vendor.name)[:10].rstrip("-").upper()
         reference = f"AP-{run_id[:6]}-{vendor_slug}-{seq:04d}-{ref_suffix}"
         inv_seq = inv_seq_by_vendor.get(vendor.id)
         if inv_seq is None:

--- a/tests/test_generator_features.py
+++ b/tests/test_generator_features.py
@@ -1,0 +1,182 @@
+from dataclasses import dataclass
+from datetime import date
+import sys
+from pathlib import Path
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+# Minimal pydantic stub so ai.schema imports succeed
+fake_pydantic = types.ModuleType("pydantic")
+
+class BaseModel:
+    def __init__(self, **data):
+        for k, v in data.items():
+            setattr(self, k, v)
+
+def field_validator(*args, **kwargs):
+    def decorator(fn):
+        return fn
+    return decorator
+
+def Field(default=None, **kwargs):
+    return default
+
+fake_pydantic.BaseModel = BaseModel
+fake_pydantic.field_validator = field_validator
+fake_pydantic.Field = Field
+sys.modules["pydantic"] = fake_pydantic
+
+from synthap.engine.generator import generate_from_plan
+
+
+@dataclass
+class Vendor:
+    id: str
+    name: str
+    xero_contact_id: str
+    xero_account_number: str | None
+    is_supplier: bool
+    payment_terms: dict
+
+
+@dataclass
+class Item:
+    id: str
+    code: str
+    name: str
+    unit_price: float
+    account_code: str
+    tax_code: str
+    price_variance_pct: float = 0.1
+
+
+@dataclass
+class Catalogs:
+    vendors: list
+    items: list
+    accounts: list
+    tax_codes: list
+    vendor_items: dict
+
+
+@dataclass
+class DateRange:
+    start: date
+    end: date
+
+
+@dataclass
+class VendorPlan:
+    vendor_id: str
+    count: int
+    min_lines_per_invoice: int = 1
+    max_lines_per_invoice: int = 3
+
+
+@dataclass
+class Plan:
+    total_count: int
+    date_range: DateRange
+    vendor_mix: list
+    allow_price_variation: bool | None = None
+    price_variation_pct: float | None = None
+    business_days_only: bool = True
+    status: str | None = None
+    currency: str | None = None
+
+
+def _basic_catalog() -> Catalogs:
+    vendor = Vendor(
+        id="VEND-ACME",
+        name="ACME & Sons Co.",
+        xero_contact_id="c1",
+        xero_account_number=None,
+        is_supplier=True,
+        payment_terms={"type": "DAYSAFTERBILLDATE", "days": 30},
+    )
+    item = Item(
+        id="item-1",
+        code="IT1",
+        name="Widget",
+        unit_price=10.0,
+        account_code="400",
+        tax_code="NONE",
+    )
+    return Catalogs(
+        vendors=[vendor],
+        items=[item],
+        accounts=[],
+        tax_codes=[],
+        vendor_items={"VEND-ACME": ["IT1"]},
+    )
+
+
+def test_reference_slug_trimmed():
+    cat = _basic_catalog()
+    plan = Plan(
+        total_count=1,
+        date_range=DateRange(start=date(2024, 3, 1), end=date(2024, 3, 3)),
+        vendor_mix=[VendorPlan(vendor_id="VEND-ACME", count=1)],
+        currency="USD",
+    )
+    invs = generate_from_plan(cat=cat, plan=plan, run_id="RUN123456", seed=1)
+    ref = invs[0].reference
+    assert "--" not in ref  # slug truncation shouldn't leave double dashes
+    assert "ACME-SONS" in ref
+
+
+def test_business_days_only_controls_weekends():
+    cat = _basic_catalog()
+    plan_bd = Plan(
+        total_count=3,
+        date_range=DateRange(start=date(2024, 3, 1), end=date(2024, 3, 3)),
+        vendor_mix=[VendorPlan(vendor_id="VEND-ACME", count=3, min_lines_per_invoice=1, max_lines_per_invoice=1)],
+        business_days_only=True,
+    )
+    invs_bd = generate_from_plan(cat, plan_bd, run_id="BD", seed=0)
+    assert all(inv.date.weekday() < 5 for inv in invs_bd)
+
+    plan_all = Plan(
+        total_count=3,
+        date_range=DateRange(start=date(2024, 3, 1), end=date(2024, 3, 3)),
+        vendor_mix=[VendorPlan(vendor_id="VEND-ACME", count=3, min_lines_per_invoice=1, max_lines_per_invoice=1)],
+        business_days_only=False,
+    )
+    invs_all = generate_from_plan(cat, plan_all, run_id="AL", seed=0)
+    assert any(inv.date.weekday() >= 5 for inv in invs_all)
+
+
+def test_item_selection_unique_and_repeat():
+    vendor = _basic_catalog().vendors[0]
+    items = [
+        Item(id="i1", code="IT1", name="A", unit_price=1, account_code="400", tax_code="NONE"),
+        Item(id="i2", code="IT2", name="B", unit_price=1, account_code="400", tax_code="NONE"),
+        Item(id="i3", code="IT3", name="C", unit_price=1, account_code="400", tax_code="NONE"),
+    ]
+    cat_many = Catalogs(
+        vendors=[vendor],
+        items=items,
+        accounts=[],
+        tax_codes=[],
+        vendor_items={"VEND-ACME": [it.code for it in items]},
+    )
+    plan = Plan(
+        total_count=1,
+        date_range=DateRange(start=date(2024, 3, 1), end=date(2024, 3, 1)),
+        vendor_mix=[VendorPlan(vendor_id="VEND-ACME", count=1, min_lines_per_invoice=2, max_lines_per_invoice=2)],
+    )
+    invs = generate_from_plan(cat_many, plan, run_id="R1", seed=0)
+    codes = [ln.item_code for ln in invs[0].lines]
+    assert len(codes) == len(set(codes))
+
+    cat_one = Catalogs(
+        vendors=[vendor],
+        items=[items[0]],
+        accounts=[],
+        tax_codes=[],
+        vendor_items={"VEND-ACME": [items[0].code]},
+    )
+    invs2 = generate_from_plan(cat_one, plan, run_id="R2", seed=0)
+    codes2 = [ln.item_code for ln in invs2[0].lines]
+    assert len(set(codes2)) < len(codes2)


### PR DESCRIPTION
## Summary
- trim trailing dashes from slugified vendor names when building invoice references
- add generator test suite covering slug trimming, business-day handling, and line-item selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afd14478908320bb412faae81f10e4