### PR TITLE
Add Streamlit dashboard and generation interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ openai = "^1.40.0"
 fastapi = "^0.114.0"
 uvicorn = {version="^0.30.6", extras=["standard"]}
 python-dotenv = "^1.1.1"
+streamlit = "^1.37.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.2"

--- a/src/synthap/ui/__init__.py
+++ b/src/synthap/ui/__init__.py
@@ -1,0 +1,2 @@
+"""Streamlit user interface for the Synthetic AP application."""
+

--- a/src/synthap/ui/app.py
+++ b/src/synthap/ui/app.py
@@ -1,0 +1,22 @@
+"""Entry point for the Streamlit front end."""
+
+import streamlit as st
+
+
+def main() -> None:
+    """Render the landing page.
+
+    Streamlit automatically discovers additional pages placed in the
+    ``pages`` directory that sits alongside this module.  The landing page is
+    intentionally minimal and directs the user to the sidebar where page
+    navigation lives.
+    """
+
+    st.set_page_config(page_title="Synthetic AP", layout="wide")
+    st.title("Synthetic AP")
+    st.write("Use the sidebar to navigate between application sections.")
+
+
+if __name__ == "__main__":  # pragma: no cover - streamlit entry point
+    main()
+

--- a/src/synthap/ui/pages/1_Dashboard.py
+++ b/src/synthap/ui/pages/1_Dashboard.py
@@ -1,0 +1,56 @@
+"""Dashboard page for the Streamlit UI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+from synthap.cli import latest_run_id
+from synthap.config.settings import settings
+from synthap.xero.oauth import TokenStore
+
+
+def _status_table() -> pd.DataFrame:
+    """Collect basic connectivity diagnostics."""
+
+    data_dir_ok = Path(settings.data_dir).exists() if settings.data_dir else False
+    openai_ok = bool(settings.openai_api_key)
+    xero_ok = TokenStore.load() is not None
+
+    return pd.DataFrame(
+        [
+            {"service": "Data directory", "connected": data_dir_ok},
+            {"service": "OpenAI", "connected": openai_ok},
+            {"service": "Xero token", "connected": xero_ok},
+        ]
+    )
+
+
+def _last_seed() -> str | None:
+    run_id = latest_run_id()
+    if not run_id:
+        return None
+    try:
+        return run_id.split("-")[-1]
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+def main() -> None:
+    st.title("Dashboard")
+
+    seed = _last_seed()
+    if seed:
+        st.metric("Last generated seed", seed)
+    else:
+        st.info("No generation runs found.")
+
+    st.subheader("Connectivity")
+    st.table(_status_table())
+
+
+if __name__ == "__main__":  # pragma: no cover - streamlit entry point
+    main()
+

--- a/src/synthap/ui/pages/2_Catalogs.py
+++ b/src/synthap/ui/pages/2_Catalogs.py
@@ -1,0 +1,33 @@
+"""Catalog browsing page."""
+
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+from synthap.catalogs.loader import load_catalogs
+from synthap.config.settings import settings
+
+
+def _as_df(records: list[dict]) -> pd.DataFrame:
+    return pd.DataFrame(records)
+
+
+def main() -> None:
+    st.title("Catalogs")
+    cat = load_catalogs(settings.data_dir)
+
+    st.subheader("Vendors")
+    st.dataframe(_as_df([v.model_dump() for v in cat.vendors]))
+
+    st.subheader("Items")
+    st.dataframe(_as_df([i.model_dump() for i in cat.items]))
+
+    st.subheader("Vendor items")
+    vi = [{"vendor_id": vid, "item_codes": ", ".join(codes)} for vid, codes in cat.vendor_items.items()]
+    st.dataframe(_as_df(vi))
+
+
+if __name__ == "__main__":  # pragma: no cover - streamlit entry point
+    main()
+

--- a/src/synthap/ui/pages/3_Config.py
+++ b/src/synthap/ui/pages/3_Config.py
@@ -1,0 +1,33 @@
+"""Configuration viewer page."""
+
+from __future__ import annotations
+
+import yaml
+import streamlit as st
+
+from synthap.config.runtime_config import _defaults_path, _runtime_path
+from synthap.config.settings import settings
+
+
+def _load(path) -> dict:
+    if not path.exists():
+        return {}
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def main() -> None:
+    st.title("Configuration")
+    defaults = _load(_defaults_path(settings.data_dir))
+    runtime = _load(_runtime_path(settings.data_dir))
+
+    st.subheader("Service defaults")
+    st.json(defaults)
+
+    st.subheader("Runtime configuration")
+    st.json(runtime)
+
+
+if __name__ == "__main__":  # pragma: no cover - streamlit entry point
+    main()
+

--- a/src/synthap/ui/pages/4_Runs.py
+++ b/src/synthap/ui/pages/4_Runs.py
@@ -1,0 +1,54 @@
+"""Run explorer page."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+from synthap.cli import runs_dir
+
+
+def _available_runs() -> list[str]:
+    return sorted([p.name for p in runs_dir().iterdir() if p.is_dir()])
+
+
+def _load_json(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main() -> None:
+    st.title("Generated Runs")
+    run_ids = _available_runs()
+    if not run_ids:
+        st.info("No runs available. Generate invoices first.")
+        return
+
+    selected = st.selectbox("Run", run_ids)
+    base = runs_dir() / selected
+
+    st.write(f"Run directory: {base}")
+
+    report = _load_json(base / "generation_report.json")
+    if report:
+        st.subheader("Generation report")
+        st.json(report)
+
+    inv_path = base / "invoices.parquet"
+    line_path = base / "invoice_lines.parquet"
+    if inv_path.exists():
+        st.subheader("Invoices")
+        st.dataframe(pd.read_parquet(inv_path))
+    if line_path.exists():
+        st.subheader("Invoice lines")
+        st.dataframe(pd.read_parquet(line_path))
+
+
+if __name__ == "__main__":  # pragma: no cover - streamlit entry point
+    main()
+

--- a/src/synthap/ui/pages/5_Generator.py
+++ b/src/synthap/ui/pages/5_Generator.py
@@ -1,0 +1,117 @@
+"""Invoice generation page."""
+
+from __future__ import annotations
+
+import random
+import secrets
+from datetime import date
+
+import streamlit as st
+from slugify import slugify
+
+from synthap.ai.planner import plan_from_query
+from synthap.catalogs.loader import load_catalogs
+from synthap.cli import runs_dir
+from synthap.config.runtime_config import load_runtime_config
+from synthap.config.settings import settings
+from synthap.data.storage import to_rows, write_parquet
+from synthap.engine.generator import generate_from_plan
+from synthap.engine.payments import select_invoices_to_pay
+from synthap.engine.validators import validate_invoices
+from synthap.reports.report import write_json
+
+
+def _vendor_options(cat):
+    return [v.name for v in cat.vendors]
+
+
+def _vendor_name_to_id(cat, names):
+    by_name = {v.name: v.id for v in cat.vendors}
+    return [by_name[n] for n in names if n in by_name]
+
+
+def main() -> None:
+    st.title("Generate invoices")
+
+    cat = load_catalogs(settings.data_dir)
+
+    with st.form("gen_form"):
+        query = st.text_area("NLP query", height=100)
+        vendors = st.multiselect("Vendors", _vendor_options(cat))
+        max_lines = st.number_input("Max line items per invoice", min_value=1, value=5)
+        no_tax = st.checkbox("Generate without tax")
+        pay_count = st.number_input("Invoices to mark for payment", min_value=0, value=0)
+        pay_on_due = st.checkbox("Pay exactly on due date")
+        allow_overdue = st.checkbox("Allow overdue payments")
+        pay_before_due = st.checkbox("Pay before due date")
+        submitted = st.form_submit_button("Generate")
+
+    if not submitted or not query:
+        return
+
+    cfg = load_runtime_config(settings.data_dir)
+    plan = plan_from_query(query, cat, today=date.today())
+
+    if vendors:
+        ids = _vendor_name_to_id(cat, vendors)
+        plan.vendor_mix = [vp for vp in plan.vendor_mix if vp.vendor_id in ids]
+
+    for vp in plan.vendor_mix:
+        available = len(cat.vendor_items.get(vp.vendor_id, [])) or len(cat.items)
+        vp.max_lines_per_invoice = min(int(max_lines), available)
+        if vp.min_lines_per_invoice > vp.max_lines_per_invoice:
+            vp.min_lines_per_invoice = vp.max_lines_per_invoice
+
+    plan.normalize_counts()
+
+    seed = secrets.randbits(32)
+    run_id = slugify(f"{date.today().isoformat()}-{seed}")[:24]
+
+    invoices = generate_from_plan(
+        cat=cat,
+        plan=plan,
+        run_id=run_id,
+        seed=seed,
+        force_no_tax=no_tax,
+        cfg=cfg,
+    )
+    validate_invoices(cat, invoices)
+
+    inv_df, line_df = to_rows(invoices)
+    base = runs_dir() / run_id
+    base.mkdir(parents=True, exist_ok=True)
+    write_parquet(inv_df, base / "invoices.parquet")
+    write_parquet(line_df, base / "invoice_lines.parquet")
+
+    all_refs = [inv.reference for inv in invoices]
+    rng = random.Random(seed)
+    pay_refs = select_invoices_to_pay(
+        all_refs,
+        int(pay_count) if pay_count else None,
+        False,
+        cfg.payments.pay_when_unspecified,
+        rng,
+    )
+    write_json({"run_id": run_id, "references": pay_refs}, base / "to_pay.json")
+
+    report = {
+        "run_id": run_id,
+        "query": query,
+        "seed_used": seed,
+        "count": len(invoices),
+        "payment_instructions": {
+            "count": int(pay_count) if pay_count else None,
+            "pay_on_due_date": bool(pay_on_due),
+            "allow_overdue": bool(allow_overdue),
+            "pay_before_due": bool(pay_before_due),
+            "references": pay_refs,
+        },
+    }
+    write_json(report, base / "generation_report.json")
+
+    st.success(f"Generated run {run_id}")
+
+
+if __name__ == "__main__":  # pragma: no cover - streamlit entry point
+    main()
+


### PR DESCRIPTION
## Summary
- add Streamlit dependency
- build Streamlit front end with dashboard, catalog/config viewers, run explorer and generation form

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b62646c6108320a83df7219fbbfef9