### PR TITLE
feat: clamp plan dates to current day

### DIFF
--- a/src/synthap/ai/planner.py
+++ b/src/synthap/ai/planner.py
@@ -81,6 +81,23 @@ def _sanitize_plan(cat: Catalogs, plan: Plan, cfg) -> Plan:
 
     return plan
 
+
+def clamp_plan_to_today(plan: Plan, today: date) -> Plan:
+    """Clamp a plan's date range so it does not extend beyond ``today``.
+
+    If the plan's ``end`` date is in the future relative to ``today`` the
+    ``end`` is set to ``today``.  If the ``start`` date is also in the future it
+    is likewise moved to ``today`` to avoid an invalid range.
+
+    The function mutates and returns the provided ``plan`` for convenience.
+    """
+
+    if plan.date_range.end > today:
+        plan.date_range.end = today
+        if plan.date_range.start > today:
+            plan.date_range.start = today
+    return plan
+
 def plan_from_query(query: str, cat: Catalogs, today: date) -> Plan:
     cfg = load_runtime_config(settings.data_dir)
     base_range = resolve_period_au(query, today=today)

--- a/src/synthap/config/runtime_config.py
+++ b/src/synthap/config/runtime_config.py
@@ -50,6 +50,10 @@ class PaymentCfg(BaseModel):
     overdue_count: int = 0
 
 
+# Resolve forward references now that PaymentCfg is defined
+RuntimeConfig.model_rebuild()
+
+
 def _config_dir(base_dir: str) -> Path:
     p = Path(base_dir) / "config"
     p.mkdir(parents=True, exist_ok=True)

--- a/src/synthap/ui/pages/5_Generator.py
+++ b/src/synthap/ui/pages/5_Generator.py
@@ -9,7 +9,7 @@ from datetime import date
 import streamlit as st
 from slugify import slugify
 
-from synthap.ai.planner import plan_from_query
+from synthap.ai.planner import clamp_plan_to_today, plan_from_query
 from synthap.catalogs.loader import load_catalogs
 from synthap.cli import runs_dir
 from synthap.config.runtime_config import load_runtime_config
@@ -40,6 +40,7 @@ def main() -> None:
         vendors = st.multiselect("Vendors", _vendor_options(cat))
         max_lines = st.number_input("Max line items per invoice", min_value=1, value=5)
         no_tax = st.checkbox("Generate without tax")
+        clamp_dates = st.checkbox("Limit dates to today", value=True)
         pay_count = st.number_input("Invoices to mark for payment", min_value=0, value=0)
         pay_on_due = st.checkbox("Pay exactly on due date")
         allow_overdue = st.checkbox("Allow overdue payments")
@@ -51,6 +52,8 @@ def main() -> None:
 
     cfg = load_runtime_config(settings.data_dir)
     plan = plan_from_query(query, cat, today=date.today())
+    if clamp_dates:
+        clamp_plan_to_today(plan, date.today())
 
     if vendors:
         ids = _vendor_name_to_id(cat, vendors)

--- a/tests/test_plan_clamp.py
+++ b/tests/test_plan_clamp.py
@@ -1,0 +1,51 @@
+from datetime import date
+import os
+
+import sys
+from pathlib import Path
+import importlib
+
+sys.modules.pop("pydantic", None)
+sys.modules["pydantic"] = importlib.import_module("pydantic")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+# minimal settings env vars so synthap.config.settings can load
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("XERO_CLIENT_ID", "cid")
+os.environ.setdefault("XERO_CLIENT_SECRET", "csecret")
+os.environ.setdefault("XERO_REDIRECT_URI", "http://localhost")
+os.environ.setdefault("XERO_SCOPES", "accounting.transactions")
+os.environ.setdefault("TIMEZONE", "UTC")
+os.environ.setdefault("DEFAULT_SEED", "1")
+os.environ.setdefault("FISCAL_YEAR_START_MONTH", "7")
+os.environ.setdefault("DATA_DIR", str(Path(__file__).resolve().parents[1] / "data"))
+os.environ.setdefault("RUNS_DIR", str(Path(__file__).resolve().parents[1] / "runs"))
+os.environ.setdefault("XERO_TOKEN_FILE", "token.json")
+
+from synthap.ai.schema import DateRange, Plan, VendorPlan
+from synthap.ai.planner import clamp_plan_to_today
+
+
+def _basic_plan(start, end):
+    return Plan(
+        total_count=1,
+        date_range=DateRange(start=start, end=end),
+        vendor_mix=[VendorPlan(vendor_id="V1", count=1)],
+    )
+
+
+def test_clamp_truncates_end():
+    today = date(2024, 3, 15)
+    plan = _basic_plan(date(2024, 3, 1), date(2024, 4, 1))
+    clamp_plan_to_today(plan, today)
+    assert plan.date_range.end == today
+    assert plan.date_range.start == date(2024, 3, 1)
+
+
+def test_clamp_future_start():
+    today = date(2024, 3, 15)
+    plan = _basic_plan(date(2024, 4, 10), date(2024, 4, 20))
+    clamp_plan_to_today(plan, today)
+    assert plan.date_range.start == today
+    assert plan.date_range.end == today


### PR DESCRIPTION
## Summary
- add helper to clamp AI plans to today
- expose "Limit dates to today" option in generator UI
- resolve runtime config forward references
- test plan date clamping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be7758a0708320a3e0b2941c154a98