### PR TITLE
feat: clamp plan dates and reset catalogs

### DIFF
--- a/src/synthap/ai/planner.py
+++ b/src/synthap/ai/planner.py
@@ -81,6 +81,23 @@ def _sanitize_plan(cat: Catalogs, plan: Plan, cfg) -> Plan:
 
     return plan
 
+
+def clamp_plan_to_today(plan: Plan, today: date) -> Plan:
+    """Clamp a plan's date range so it does not extend beyond ``today``.
+
+    If the plan's ``end`` date is in the future relative to ``today`` the
+    ``end`` is set to ``today``.  If the ``start`` date is also in the future it
+    is likewise moved to ``today`` to avoid an invalid range.
+
+    The function mutates and returns the provided ``plan`` for convenience.
+    """
+
+    if plan.date_range.end > today:
+        plan.date_range.end = today
+        if plan.date_range.start > today:
+            plan.date_range.start = today
+    return plan
+
 def plan_from_query(query: str, cat: Catalogs, today: date) -> Plan:
     cfg = load_runtime_config(settings.data_dir)
     base_range = resolve_period_au(query, today=today)

--- a/src/synthap/config/reset.py
+++ b/src/synthap/config/reset.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+
+def reset_all(base_dir: str) -> None:
+    """Revert catalog and config YAMLs back to repository defaults.
+
+    Parameters
+    ----------
+    base_dir:
+        Base data directory containing ``catalogs`` and ``config``.
+    """
+    base = Path(base_dir)
+    for sub in ("catalogs", "config"):
+        path = base / sub
+        if path.exists():
+            # restore tracked files
+            subprocess.run(["git", "checkout", "--", str(path)], check=True)
+            # remove untracked files beneath the directory
+            subprocess.run(["git", "clean", "-f", str(path)], check=True)

--- a/src/synthap/config/runtime_config.py
+++ b/src/synthap/config/runtime_config.py
@@ -50,6 +50,10 @@ class PaymentCfg(BaseModel):
     overdue_count: int = 0
 
 
+# Resolve forward references now that PaymentCfg is defined
+RuntimeConfig.model_rebuild()
+
+
 def _config_dir(base_dir: str) -> Path:
     p = Path(base_dir) / "config"
     p.mkdir(parents=True, exist_ok=True)

--- a/src/synthap/ui/pages/5_Generator.py
+++ b/src/synthap/ui/pages/5_Generator.py
@@ -9,7 +9,7 @@ from datetime import date
 import streamlit as st
 from slugify import slugify
 
-from synthap.ai.planner import plan_from_query
+from synthap.ai.planner import clamp_plan_to_today, plan_from_query
 from synthap.catalogs.loader import load_catalogs
 from synthap.cli import runs_dir
 from synthap.config.runtime_config import load_runtime_config
@@ -40,6 +40,7 @@ def main() -> None:
         vendors = st.multiselect("Vendors", _vendor_options(cat))
         max_lines = st.number_input("Max line items per invoice", min_value=1, value=5)
         no_tax = st.checkbox("Generate without tax")
+        clamp_dates = st.checkbox("Limit dates to today", value=True)
         pay_count = st.number_input("Invoices to mark for payment", min_value=0, value=0)
         pay_on_due = st.checkbox("Pay exactly on due date")
         allow_overdue = st.checkbox("Allow overdue payments")
@@ -51,6 +52,8 @@ def main() -> None:
 
     cfg = load_runtime_config(settings.data_dir)
     plan = plan_from_query(query, cat, today=date.today())
+    if clamp_dates:
+        clamp_plan_to_today(plan, date.today())
 
     if vendors:
         ids = _vendor_name_to_id(cat, vendors)

--- a/streamlit_app/pages/2_Config.py
+++ b/streamlit_app/pages/2_Config.py
@@ -7,11 +7,17 @@ import yaml
 import streamlit as st
 
 from synthap.config.runtime_config import (
+    AIConfig,
+    ArtifactsCfg,
+    GeneratorCfg,
+    PaymentCfg,
     RuntimeConfig,
     _defaults_path,
     _runtime_path,
+    load_runtime_config,
     save_runtime_config,
 )
+from synthap.config.reset import reset_all
 from synthap.config.settings import settings
 
 
@@ -33,40 +39,103 @@ def _flatten(d: dict, prefix: str = "") -> list[dict[str, object]]:
     return rows
 
 
-def _unflatten(rows: list[dict[str, object]]) -> dict:
-    out: dict[str, object] = {}
-    for row in rows:
-        parts = str(row.get("key", "")).split(".")
-        cur = out
-        for part in parts[:-1]:
-            cur = cur.setdefault(part, {})
-        cur[parts[-1]] = row.get("value")
-    return out
-
-
 def main() -> None:
     st.title("Configuration")
     defaults = _load(_defaults_path(settings.data_dir))
-    runtime_raw = _load(_runtime_path(settings.data_dir))
+    cfg = load_runtime_config(settings.data_dir)
 
     st.subheader("Service defaults")
     st.dataframe(pd.DataFrame(_flatten(defaults)))
 
     st.subheader("Runtime configuration")
-    runtime_rows = _flatten(runtime_raw)
-    edited = st.data_editor(pd.DataFrame(runtime_rows), num_rows="dynamic", use_container_width=True)
+    with st.form("runtime_cfg"):
+        st.markdown("### AI")
+        ai_enabled = st.checkbox("Enabled", value=cfg.ai.enabled)
+        ai_model = st.text_input("Model", cfg.ai.model)
+        ai_temperature = st.number_input("Temperature", value=cfg.ai.temperature, step=0.01)
+        ai_top_p = st.number_input("Top p", value=cfg.ai.top_p, step=0.01)
+        ai_max_tokens = st.number_input("Max output tokens", value=cfg.ai.max_output_tokens)
+        ai_system_prompt = st.text_area("System prompt", value=cfg.ai.system_prompt or "")
+        ai_max_vendors = st.number_input("Max vendors", value=cfg.ai.max_vendors, step=1)
+        ai_line_desc = st.checkbox(
+            "Line item description enabled", value=cfg.ai.line_item_description_enabled
+        )
+        ai_line_prompt = st.text_input(
+            "Line item description prompt", cfg.ai.line_item_description_prompt
+        )
+
+        st.markdown("### Generator")
+        gen_allow_price_var = st.checkbox(
+            "Allow price variation", value=cfg.generator.allow_price_variation
+        )
+        gen_price_var_pct = st.number_input(
+            "Price variation pct", value=cfg.generator.price_variation_pct, step=0.01
+        )
+        gen_currency = st.text_input("Currency", cfg.generator.currency)
+        gen_status = st.text_input("Status", cfg.generator.status)
+        gen_business_days = st.checkbox(
+            "Business days only", value=cfg.generator.business_days_only
+        )
+
+        st.markdown("### Artifacts")
+        art_include_meta = st.checkbox(
+            "Include meta JSON", value=cfg.artifacts.include_meta_json
+        )
+
+        force_no_tax = st.checkbox("Force no tax", value=cfg.force_no_tax)
+
+        st.markdown("### Payments")
+        pay_on_due = st.checkbox("Pay on due date", value=cfg.payments.pay_on_due_date)
+        allow_overdue = st.checkbox("Allow overdue", value=cfg.payments.allow_overdue)
+        pay_when_unspecified = st.checkbox(
+            "Pay when unspecified", value=cfg.payments.pay_when_unspecified
+        )
+        overdue_count = st.number_input(
+            "Overdue count", value=cfg.payments.overdue_count, step=1
+        )
+
+        submitted = st.form_submit_button("Save")
+        if submitted:
+            new_cfg = RuntimeConfig(
+                ai=AIConfig(
+                    enabled=ai_enabled,
+                    model=ai_model,
+                    temperature=ai_temperature,
+                    top_p=ai_top_p,
+                    max_output_tokens=int(ai_max_tokens),
+                    system_prompt=ai_system_prompt or None,
+                    max_vendors=int(ai_max_vendors),
+                    line_item_description_enabled=ai_line_desc,
+                    line_item_description_prompt=ai_line_prompt,
+                ),
+                generator=GeneratorCfg(
+                    allow_price_variation=gen_allow_price_var,
+                    price_variation_pct=gen_price_var_pct,
+                    currency=gen_currency,
+                    status=gen_status,
+                    business_days_only=gen_business_days,
+                ),
+                artifacts=ArtifactsCfg(include_meta_json=art_include_meta),
+                force_no_tax=force_no_tax,
+                payments=PaymentCfg(
+                    pay_on_due_date=pay_on_due,
+                    allow_overdue=allow_overdue,
+                    pay_when_unspecified=pay_when_unspecified,
+                    overdue_count=int(overdue_count),
+                ),
+            )
+            save_runtime_config(new_cfg)
+            st.success("Configuration saved")
 
     col1, col2 = st.columns(2)
     with col1:
-        if st.button("Save"):
-            rows = edited.to_dict("records")
-            cfg = RuntimeConfig(**_unflatten(rows))
-            save_runtime_config(cfg)
-            st.success("Configuration saved")
-    with col2:
-        if st.button("Revert to defaults"):
+        if st.button("Revert runtime config"):
             _runtime_path(settings.data_dir).unlink(missing_ok=True)
             st.warning("Runtime configuration reset")
+    with col2:
+        if st.button("Revert all data"):
+            reset_all(settings.data_dir)
+            st.warning("All data reverted to defaults")
 
 
 if __name__ == "__main__":  # pragma: no cover - streamlit entry point

--- a/tests/test_plan_clamp.py
+++ b/tests/test_plan_clamp.py
@@ -1,0 +1,51 @@
+from datetime import date
+import os
+
+import sys
+from pathlib import Path
+import importlib
+
+sys.modules.pop("pydantic", None)
+sys.modules["pydantic"] = importlib.import_module("pydantic")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+# minimal settings env vars so synthap.config.settings can load
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("XERO_CLIENT_ID", "cid")
+os.environ.setdefault("XERO_CLIENT_SECRET", "csecret")
+os.environ.setdefault("XERO_REDIRECT_URI", "http://localhost")
+os.environ.setdefault("XERO_SCOPES", "accounting.transactions")
+os.environ.setdefault("TIMEZONE", "UTC")
+os.environ.setdefault("DEFAULT_SEED", "1")
+os.environ.setdefault("FISCAL_YEAR_START_MONTH", "7")
+os.environ.setdefault("DATA_DIR", str(Path(__file__).resolve().parents[1] / "data"))
+os.environ.setdefault("RUNS_DIR", str(Path(__file__).resolve().parents[1] / "runs"))
+os.environ.setdefault("XERO_TOKEN_FILE", "token.json")
+
+from synthap.ai.schema import DateRange, Plan, VendorPlan
+from synthap.ai.planner import clamp_plan_to_today
+
+
+def _basic_plan(start, end):
+    return Plan(
+        total_count=1,
+        date_range=DateRange(start=start, end=end),
+        vendor_mix=[VendorPlan(vendor_id="V1", count=1)],
+    )
+
+
+def test_clamp_truncates_end():
+    today = date(2024, 3, 15)
+    plan = _basic_plan(date(2024, 3, 1), date(2024, 4, 1))
+    clamp_plan_to_today(plan, today)
+    assert plan.date_range.end == today
+    assert plan.date_range.start == date(2024, 3, 1)
+
+
+def test_clamp_future_start():
+    today = date(2024, 3, 15)
+    plan = _basic_plan(date(2024, 4, 10), date(2024, 4, 20))
+    clamp_plan_to_today(plan, today)
+    assert plan.date_range.start == today
+    assert plan.date_range.end == today

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import subprocess
+
+from synthap.config.reset import reset_all
+
+
+def test_reset_all_runs_git(monkeypatch, tmp_path):
+    (tmp_path / "catalogs").mkdir()
+    (tmp_path / "config").mkdir()
+
+    calls = []
+
+    def fake_run(cmd, check):
+        calls.append(cmd)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    reset_all(str(tmp_path))
+
+    expected_catalog_checkout = ["git", "checkout", "--", str(tmp_path / "catalogs")]
+    expected_catalog_clean = ["git", "clean", "-f", str(tmp_path / "catalogs")]
+    expected_config_checkout = ["git", "checkout", "--", str(tmp_path / "config")]
+    expected_config_clean = ["git", "clean", "-f", str(tmp_path / "config")]
+
+    assert expected_catalog_checkout in calls
+    assert expected_catalog_clean in calls
+    assert expected_config_checkout in calls
+    assert expected_config_clean in calls


### PR DESCRIPTION
## Summary
- add helper to clamp AI plans to today
- expose "Limit dates to today" option in generator UI
- resolve runtime config forward references
- test plan date clamping
- allow reverting data directories to defaults and edit runtime config via structured form

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be7758a0708320a3e0b2941c154a98