### PR TITLE
Refresh Streamlit data after invoice generation

### DIFF
--- a/src/synthap/ui/pages/1_Dashboard.py
+++ b/src/synthap/ui/pages/1_Dashboard.py
@@ -12,6 +12,7 @@ from synthap.config.settings import settings
 from synthap.xero.oauth import TokenStore
 
 
+@st.cache_data
 def _status_table() -> pd.DataFrame:
     """Collect basic connectivity diagnostics."""
 
@@ -28,6 +29,7 @@ def _status_table() -> pd.DataFrame:
     )
 
 
+@st.cache_data
 def _last_seed() -> str | None:
     run_id = latest_run_id()
     if not run_id:

--- a/src/synthap/ui/pages/2_Catalogs.py
+++ b/src/synthap/ui/pages/2_Catalogs.py
@@ -9,13 +9,19 @@ from synthap.catalogs.loader import load_catalogs
 from synthap.config.settings import settings
 
 
+@st.cache_data
 def _as_df(records: list[dict]) -> pd.DataFrame:
     return pd.DataFrame(records)
 
 
+@st.cache_data
+def _load_catalogs(base_dir: str):
+    return load_catalogs(base_dir)
+
+
 def main() -> None:
     st.title("Catalogs")
-    cat = load_catalogs(settings.data_dir)
+    cat = _load_catalogs(settings.data_dir)
 
     st.subheader("Vendors")
     st.dataframe(_as_df([v.model_dump() for v in cat.vendors]))

--- a/src/synthap/ui/pages/5_Generator.py
+++ b/src/synthap/ui/pages/5_Generator.py
@@ -114,6 +114,10 @@ def main() -> None:
 
     st.success(f"Generated run {run_id}")
 
+    # Clear any cached data so other pages load fresh data and rerun the script
+    st.cache_data.clear()
+    st.experimental_rerun()
+
 
 if __name__ == "__main__":  # pragma: no cover - streamlit entry point
     main()


### PR DESCRIPTION
## Summary
- clear cached data and rerun generator after successful invoice creation
- cache dashboard diagnostics and latest seed lookup
- cache catalog loading and dataframe conversion for catalog page

## Testing
- `pytest` *(fails: No module named 'slugify', 'yaml', 'pandas', 'pydantic', 'tenacity')*

------
https://chatgpt.com/codex/tasks/task_e_68be904473808320819470289e427085