### PR TITLE
Add centralized logging and logs viewer page

### DIFF
--- a/src/synthap/__init__.py
+++ b/src/synthap/__init__.py
@@ -1,0 +1,31 @@
+"""Initialize package-wide logging configuration."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from .config.settings import settings
+
+
+def _configure_logging() -> None:
+    log_dir = Path(getattr(settings, "logs_dir", "logs"))
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    system_handler = logging.FileHandler(log_dir / "system.log")
+    system_handler.setLevel(logging.INFO)
+    error_handler = logging.FileHandler(log_dir / "error.log")
+    error_handler.setLevel(logging.ERROR)
+
+    fmt = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    system_handler.setFormatter(fmt)
+    error_handler.setFormatter(fmt)
+
+    root = logging.getLogger()
+    if not root.handlers:
+        root.setLevel(logging.INFO)
+        root.addHandler(system_handler)
+        root.addHandler(error_handler)
+
+
+_configure_logging()

--- a/src/synthap/config/settings.py
+++ b/src/synthap/config/settings.py
@@ -29,6 +29,7 @@ class Settings(BaseSettings):
     fiscal_year_start_month: int = os.getenv("FISCAL_YEAR_START_MONTH")
     data_dir: str = os.getenv("DATA_DIR")
     runs_dir: str = os.getenv("RUNS_DIR")
+    logs_dir: str = os.getenv("LOGS_DIR", default="logs")
     token_file: str = os.getenv("XERO_TOKEN_FILE")
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")

--- a/src/synthap/ui/pages/6_Logs.py
+++ b/src/synthap/ui/pages/6_Logs.py
@@ -1,0 +1,51 @@
+import json
+from pathlib import Path
+
+import streamlit as st
+
+from synthap.cli import logs_dir, runs_dir
+
+
+def _available_runs() -> list[str]:
+    return sorted([p.name for p in runs_dir().iterdir() if p.is_dir()])
+
+def _load_json(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _load_text(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    return path.read_text(encoding="utf-8")
+
+def main() -> None:
+    st.title("Logs")
+    run_ids = _available_runs()
+    if run_ids:
+        selected = st.selectbox("Run", run_ids)
+        base = runs_dir() / selected
+        xero_log = _load_json(base / "xero_log.json")
+        if xero_log:
+            st.subheader("Xero log")
+            st.json(xero_log)
+        else:
+            st.info("No xero_log.json for this run.")
+    else:
+        st.info("No runs available. Generate invoices first.")
+
+    st.subheader("System logs")
+    sys_text = _load_text(logs_dir() / "system.log")
+    err_text = _load_text(logs_dir() / "error.log")
+    if sys_text:
+        st.expander("system.log").code(sys_text)
+    if err_text:
+        st.expander("error.log").code(err_text)
+    if not sys_text and not err_text:
+        st.info("No system logs found.")
+
+
+if __name__ == "__main__":  # pragma: no cover - streamlit entry point
+    main()


### PR DESCRIPTION
## Summary
- add logs directory configuration and logging setup
- log CLI events and errors to system and error logs
- add Streamlit logs page to inspect run and system logs

## Testing
- `pytest` *(fails: No module named 'dotenv', pandas, pydantic, tenacity; KeyError: 'synthap')*


------
https://chatgpt.com/codex/tasks/task_e_68be940230588320b8d0f209af16a716