### PR TITLE
Add UI instructions page

### DIFF
--- a/src/synthap/ui/app.py
+++ b/src/synthap/ui/app.py
@@ -15,6 +15,7 @@ def main() -> None:
     st.set_page_config(page_title="Synthetic AP", layout="wide")
     st.title("Synthetic AP")
     st.write("Use the sidebar to navigate between application sections.")
+    st.page_link("pages/0_Instructions", label="Setup instructions")
 
 
 if __name__ == "__main__":  # pragma: no cover - streamlit entry point

--- a/src/synthap/ui/pages/0_Instructions.py
+++ b/src/synthap/ui/pages/0_Instructions.py
@@ -1,0 +1,36 @@
+"""Instructions page for the Streamlit UI."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+
+def main() -> None:
+    st.title("Instructions")
+    st.markdown(
+        """
+        ### Setup
+        - Install dependencies with `poetry install` or `pip install -e .`.
+        - Provide required environment variables (e.g. `OPENAI_API_KEY`, Xero OAuth settings) via a `.env` file or your shell.
+        - Authenticate with Xero using `poetry run python -m synthap.cli auth-init`.
+
+        ### Generation
+        Use the **Generate invoices** page to create invoice data from an NLP query. Runs are written under `runs/<run_id>/` for review.
+
+        ### Insertion
+        Post generated invoices to a Xero sandbox with:
+
+        ```bash
+        poetry run python -m synthap.cli insert --run-id <run_id>
+        ```
+
+        ### Caveats
+        - Designed for demos and sandbox environments – avoid production data.
+        - LLM features incur OpenAI API usage costs.
+        - Review generated invoices before inserting them into Xero.
+        """
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - streamlit entry point
+    main()


### PR DESCRIPTION
## Summary
- Add introductory Instructions page for Streamlit app
- Link to new instructions from main landing page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68be984ce2f88320b1740e6787661b71