### PR TITLE
Improve fuzzy parsing and generator UI feedback

### DIFF
--- a/tests/test_nlp_corrections.py
+++ b/tests/test_nlp_corrections.py
@@ -1,0 +1,31 @@
+from datetime import date
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from synthap.catalogs.loader import load_catalogs
+from synthap.nlp.parser import parse_nlp_to_query
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+
+
+def _catalogs():
+    return load_catalogs(str(DATA_DIR))
+
+
+def test_near_miss_vendor_corrected():
+    cat = _catalogs()
+    pq = parse_nlp_to_query(
+        "Generate 5 bills for vendor Sparky Electrical", today=date(2024, 1, 1), catalogs=cat
+    )
+    assert pq.vendor_name == "Sparky Electricals"
+
+
+def test_near_miss_period_phrase_corrected():
+    cat = _catalogs()
+    pq = parse_nlp_to_query(
+        "Generate 1 bill yesterdya", today=date(2024, 5, 10), catalogs=cat
+    )
+    assert pq.date_range.start == date(2024, 5, 9)
+    assert pq.date_range.end == date(2024, 5, 9)


### PR DESCRIPTION
## Summary
- Correct period phrases and vendor names using difflib in NLP parser
- Parse generator queries live, display extracted fields, and gate the Generate button until parsing succeeds
- Add tests for near-miss vendor and period phrase detection

## Testing
- `PYTHONPATH=src pytest tests/test_nlp_corrections.py -q`
- `OPENAI_API_KEY=key XERO_CLIENT_ID=id XERO_CLIENT_SECRET=secret XERO_REDIRECT_URI=http://localhost XERO_SCOPES=scope TIMEZONE=UTC DEFAULT_SEED=1 FISCAL_YEAR_START_MONTH=7 DATA_DIR=data RUNS_DIR=runs XERO_TOKEN_FILE=.xero_token.json PYTHONPATH=src pytest` *(fails: ImportError: cannot import name 'ConfigDict' from 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68be9957e1908320a2da7620c6b9e103